### PR TITLE
Parameters as data attributes added

### DIFF
--- a/src/will_pickdate.js
+++ b/src/will_pickdate.js
@@ -13,6 +13,7 @@
     var init_clone_val;
 
     this.element = $(element);
+    var dataoptions = this.element.data();	
 
     this.options = $.extend({
       pickerClass: 'wpd',
@@ -32,7 +33,7 @@
       allowEmpty: false,
       inputOutputFormat: 'U', // default to unix timestamp
       animationDuration: 400,
-      useFadeInOut: !$.browser.msie, // dont animate fade-in/fade-out for IE
+      useFadeInOut: true, 	//	!$.browser.msie, // dont animate fade-in/fade-out for IE
       startView: 'month', // allowed values: {time, month, year, decades}
       positionOffset: { x: 0, y: 0 },
       minDate: null, // { date: '[date-string]', format: '[date-string-interpretation-format]' }
@@ -45,7 +46,7 @@
       onShow: $.noop,   // triggered when will_pickdate pops up
       onClose: $.noop,  // triggered after will_pickdate is closed (destroyed)
       onSelect: $.noop  // triggered when a date is selected
-    }, options);
+    }, options, dataoptions);
 
     if(!this.options.initializeDate) {
       this.options.initializeDate = new Date();


### PR DESCRIPTION
Two changes in this request:  Changes for jQuery version 1.6+
1. Extended the usage with defining the parameters as '_**data-**_' attributes instead of Javascript definitions. Now the hierarchy order will be _'data-' attribute >> javascript definitions >> default values_ 
2. Fixed the browser identification bug for fade-out animation which is deprecated in later versions of jQuery.  `useFadeInOut: true,   //  !$.browser.msie,`

**Data attributes example:** 
Split at each camel case character with a hyphen '-' and lower case.  JQuery converts that to camel case automatically.

```
...
$('edate').will_pickdate ({startView = 'month' });
...
<input id='edate' />
...
```

can now be defined as

```
...
$('edate').will_pickdate ();
...
<input id='edate' data-start-view = 'month' />
...
```
